### PR TITLE
fix: shared memory request hook allocation; fixes PG15+ bootup

### DIFF
--- a/src/plpgsql_check.c
+++ b/src/plpgsql_check.c
@@ -332,7 +332,7 @@ _PG_init(void)
 		 */
 #if PG_VERSION_NUM >= 150000
 
-		prev_shmem_startup_hook = shmem_startup_hook;
+		prev_shmem_request_hook = shmem_request_hook;
 		shmem_request_hook = plpgsql_check_profiler_shmem_request;
 
 #endif


### PR DESCRIPTION
## What kind of change does this PR introduce?

* fixes shared memory request hook allocation
* previously it would not register `plpgsql_check profiler`, `plpgsql_check fstats` tranches and Postgres would error out during startup: 
  * `FATAL:  requested tranche is not registered`